### PR TITLE
Enable password sharing across all users

### DIFF
--- a/app/api/client/list/route.ts
+++ b/app/api/client/list/route.ts
@@ -13,11 +13,8 @@ export async function GET() {
       )
     }
 
-    // Fetch all clients for the user
+    // Fetch all clients
     const clients = await prisma.client.findMany({
-      where: {
-        userId,
-      },
       select: {
         id: true,
         name: true,

--- a/app/api/password/copy-username/route.ts
+++ b/app/api/password/copy-username/route.ts
@@ -32,11 +32,10 @@ export async function POST(request: NextRequest) {
 
     const { id } = validation.data
 
-    // Fetch password and ensure user owns it
+    // Fetch password by id
     const password = await prisma.password.findFirst({
       where: {
         id,
-        userId, // Ensure user owns this password
       },
       select: {
         id: true,
@@ -48,7 +47,7 @@ export async function POST(request: NextRequest) {
 
     if (!password) {
       return NextResponse.json(
-        { error: 'Password not found or access denied' },
+        { error: 'Password not found' },
         { status: 404 }
       )
     }

--- a/app/api/password/copy/route.ts
+++ b/app/api/password/copy/route.ts
@@ -34,11 +34,10 @@ export async function POST(request: NextRequest) {
 
     const { id } = validation.data
 
-    // Fetch password and ensure user owns it
+    // Fetch password by id
     const password = await prisma.password.findFirst({
       where: {
         id,
-        userId, // Ensure user owns this password
       },
       select: {
         id: true,
@@ -51,13 +50,13 @@ export async function POST(request: NextRequest) {
 
     if (!password) {
       return NextResponse.json(
-        { error: 'Password not found or access denied' },
+        { error: 'Password not found' },
         { status: 404 }
       )
     }
 
-    // Get user's encryption key
-    const userKey = await getUserKey(userId)
+    // Get the owner's encryption key
+    const userKey = await getUserKey(password.userId)
 
     // Decrypt the password
     const plaintext = await decrypt(password.ciphertext, password.iv, userKey)

--- a/app/api/password/list/route.ts
+++ b/app/api/password/list/route.ts
@@ -13,11 +13,8 @@ export async function GET() {
       )
     }
 
-    // Fetch all passwords for the user with client information
+    // Fetch all passwords with client information
     const passwords = await prisma.password.findMany({
-      where: {
-        userId,
-      },
       select: {
         id: true,
         name: true,

--- a/app/api/service/list/route.ts
+++ b/app/api/service/list/route.ts
@@ -10,11 +10,8 @@ export async function GET() {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 })
     }
 
-    // Get services for the user
+    // Get all services
     const services = await prisma.service.findMany({
-      where: {
-        userId: userId
-      },
       orderBy: [
         { isCustom: 'asc' }, // Default services first
         { name: 'asc' }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
+import tailwindcss from 'tailwindcss'
+import postcssNesting from 'postcss-nesting'
 
-export default config;
+const config = {
+  plugins: [tailwindcss, postcssNesting],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- update PostCSS config for vitest
- allow any user to list clients, services and passwords
- allow password copy by id regardless of owner
- return username for any password

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_6841aaeef3f8832182efc81fe483808e